### PR TITLE
Partially address issues in bootstrap themes

### DIFF
--- a/assets/css/apcal.css
+++ b/assets/css/apcal.css
@@ -75,7 +75,7 @@ div.socialNetworks span.googleplus div {
 
 /*span.print {float: right; vertical-align: top;}*/
 
-div.tooltip {
+div.apcaltooltip {
     display: none;
     position: absolute;
     border: 2px solid;
@@ -84,29 +84,29 @@ div.tooltip {
     z-index: 100;
 }
 
-div.tooltip div.summary {
+div.apcaltooltip div.summary {
     padding: 10px;
     color: #fff;
 }
 
-div.tooltip div.details {
+div.apcaltooltip div.details {
     padding: 10px;
     color: #000;
 }
 
-div.tooltip div.details div.info {
-    white-space: nowrap;
+div.apcaltooltip div.details div.info {
+    white-space: normal;
     padding: 0 0 10px 0;
 }
 
-div.tooltip div.details img {
+div.apcaltooltip div.details img {
     float: left;
     width: 50px;
     margin: 0 10px 10px 0;
     border: 1px solid #999;
 }
 
-div.tooltip div.details div.click {
+div.apcaltooltip div.details div.click {
     border-top: 1px solid #aaa;
 }
 

--- a/templates/apcal_monthly.tpl
+++ b/templates/apcal_monthly.tpl
@@ -2,7 +2,7 @@
     function showBox(id) {
         var box = document.getElementById(id);
         box.style.display = "inline";
-        moveBox(id);
+        //moveBox(id);
     }
 
     function hideBox(id) {
@@ -128,8 +128,7 @@
                             <td class="noevent" style="<{$frame_css}>">&nbsp;</td>
                         <{elseif $e[$day][$slot].first}>
                             <td colspan="<{$e[$day][$slot].duration}>" class="event" style="<{$frame_css}>"
-                                onmouseover="showBox('<{$id}>');" onmouseout="hideBox('<{$id}>');"
-                                onmousemove="moveBox('<{$id}>');">
+                                onmouseover="showBox('<{$id}>');" onmouseout="hideBox('<{$id}>');">
                                 <a href="<{$events[$id].link}>"
                                    style="border-left-color: <{$cats_color[$event.cat]}>; border-bottom-color: <{$cats_color[$event.cat]}>; background: <{$event_bgcolor}>; color: <{$event_color}>;">
                                     <{if $events[$id].extkey0 == 1}><img src="<{$ro_image}>" height="12px"
@@ -138,7 +137,7 @@
                                     <{$events[$id].summary}>
                                 </a>
                                 <{if !$for_print}>
-                                    <div id="<{$id}>" class="tooltip"
+                                    <div id="<{$id}>" class="apcaltooltip"
                                          style="border-color: <{$cats_color[$event.cat]}>;">
                                         <div class="summary" style="background: <{$cats_color[$event.cat]}>;">
                                             <{if $events[$id].extkey0 == 1}><img src="<{$ro_image}>" height="15px"


### PR DESCRIPTION
Issue #11 identified several problems.

The "overflow" is fixed by canceling `white-space: nowrap;`  in assets/css/apcal.css:98

The issues with bootstrap themes are more complicated.

A `class="tooltip"` has a special meaning in bootstrap. Without additional boostrap specific code, this will result in the info boxes always being hidden. Changing the usage of the class "tooltip" to "apcaltooltip" solves this.

The movement tracking calculations do not work in some cases, and bootstrap is one of those cases. The current code assumes that position offsets and screen coordinates all start from a common origin (top left corner of page.) 

In bootstrap the grid elements are absolutely positioned, so offsets within those elements are relative to that position. This results in the movement calculations positioning the apcaltooltip boxes completely off screen.

This "fix" sidesteps the issue by skipping the moveBox() repositioning. There remains a visual issue where boxes for the rightmost column are squeezed to fit, but everything is consistent and visible across themes.

This caught my eye as a compatibility issue with 2.5.9, so this was really just part of identifying the issues. Hopefully someone can use this to create a proper fix.